### PR TITLE
Add application shortcut to appdir as well as start menu

### DIFF
--- a/{{ cookiecutter.dir_name }}/briefcase.wxs
+++ b/{{ cookiecutter.dir_name }}/briefcase.wxs
@@ -44,6 +44,8 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder">
                 <Directory Id="AppDir" Name="{{ cookiecutter.formal_name }}">
+                    <Directory Id="WorkingDir" Name="app"> </Directory>
+                
                     <Component KeyPath="yes"
                             Id="ApplicationShortcuts"
                             Guid="12345678-1234-1234-1234-222222222222">
@@ -57,8 +59,8 @@
                                 Icon="ProductIcon"
                                 Description="{{ cookiecutter.description }}"
                                 Target="[DIR_python]\pythonw.exe"
-                                WorkingDirectory="AppDir"
-                                Arguments="app\start.py" />
+                                WorkingDirectory="WorkingDir"
+                                Arguments="start.py" />
 <!-- SHORTCUTS -->
                     </Component>
 <!-- CONTENT -->
@@ -80,8 +82,8 @@
                                 Icon="ProductIcon"
                                 Description="{{ cookiecutter.description }}"
                                 Target="[DIR_python]\pythonw.exe"
-                                WorkingDirectory="AppDir"
-                                Arguments="app\start.py" />
+                                WorkingDirectory="WorkingDir"
+                                Arguments="start.py" />
 <!-- SHORTCUTS -->
                         <RegistryValue
                                 Root="HKCU"

--- a/{{ cookiecutter.dir_name }}/briefcase.wxs
+++ b/{{ cookiecutter.dir_name }}/briefcase.wxs
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <?define ProductVersion = "{{ cookiecutter.version }}" ?>
 <?define ProductUpgradeCode = "{{ cookiecutter.guid }}" ?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
    <Product
             Id="*"
             UpgradeCode="$(var.ProductUpgradeCode)"
@@ -43,6 +44,23 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder">
                 <Directory Id="AppDir" Name="{{ cookiecutter.formal_name }}">
+                    <Component KeyPath="yes"
+                            Id="ApplicationShortcuts"
+                            Guid="12345678-1234-1234-1234-222222222222">
+                        <CreateFolder>
+                            <util:PermissionEx User="Users" GenericAll="yes"/>
+                        </CreateFolder>
+<!-- SHORTCUTS_PROVIDED -->
+                        <Shortcut
+                                Id="ApplicationShortcut1"
+                                Name="{{ cookiecutter.formal_name }}"
+                                Icon="ProductIcon"
+                                Description="{{ cookiecutter.description }}"
+                                Target="[DIR_python]\pythonw.exe"
+                                WorkingDirectory="AppDir"
+                                Arguments="app\start.py" />
+<!-- SHORTCUTS -->
+                    </Component>
 <!-- CONTENT -->
                 </Directory>
             </Directory>
@@ -53,11 +71,11 @@
         </Directory>
             <DirectoryRef Id="ApplicationProgramsFolder">
                     <Component
-                            Id="ApplicationShortcuts"
+                            Id="StartMenuShortcuts"
                             Guid="12345678-1234-1234-1234-333333333333">
 <!-- SHORTCUTS_PROVIDED -->
                         <Shortcut
-                                Id="ApplicationShortcut1"
+                                Id="StartMenuShortcut1"
                                 Name="{{ cookiecutter.formal_name }}"
                                 Icon="ProductIcon"
                                 Description="{{ cookiecutter.description }}"
@@ -86,6 +104,7 @@
 <!-- CONTENTREFS -->
 
             <ComponentRef Id="ApplicationShortcuts"/>
+            <ComponentRef Id="StartMenuShortcuts"/>
         </Feature>
 
         <UI Id="UserInterface">


### PR DESCRIPTION
This means people navigating to the app folder in explorer can still start the app easily.

This requires a minor update in briefcase, provided in https://github.com/pybee/briefcase/pull/189